### PR TITLE
Set up basic NPC Spawner & Update main level

### DIFF
--- a/Assets/Animation/NPC02_Anim/NPC02_RunRightAni.anim
+++ b/Assets/Animation/NPC02_Anim/NPC02_RunRightAni.anim
@@ -111,8 +111,8 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events:
-  - time: 0.33333334
-    functionName: 
+  - time: 0
+    functionName: PlayFootstepSound
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/Prefabs/Explosions.prefab
+++ b/Assets/Prefabs/Explosions.prefab
@@ -45,3 +45,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _explosionPrefab: {fileID: 2670021924902932536, guid: 99bb463697cb46c46885a8034d76fd4c,
     type: 3}
+  _explosionSound: event:/Explosion_1

--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -7,14 +7,7 @@ public class CameraController : MonoBehaviour
     public GameObject subject;
     public Vector3 positionOffset;
 
-    // Start is called before the first frame update
-    void Start()
-    {
-        //positionOffset = this.transform.position - subject.transform.position; 
-    }
-
-    // Update is called once per frame
-    void Update()
+    void LateUpdate()  // Changing position in LateUpdate avoids jittery camera movement.
     {
         this.transform.position = subject.transform.position + positionOffset; 
     }

--- a/Assets/Scripts/Destructible.cs
+++ b/Assets/Scripts/Destructible.cs
@@ -7,11 +7,16 @@ using UnityEngine;
 public class Destructible : MonoBehaviour {
     [SerializeField] GameObject _shatteredPrefab;
     [SerializeField] float _necessaryImpactSize = 10f;
+    [FMODUnity.EventRef, SerializeField] string _destructionSound = "";
 
     void OnCollisionEnter(Collision collision) {
         if (collision.impulse.magnitude > _necessaryImpactSize && collision.gameObject.layer == 11) {
             Object.Instantiate(_shatteredPrefab, this.transform.position, this.transform.rotation);
             Object.Destroy(this.gameObject);
+
+            if (_destructionSound != "") {
+                FMODUnity.RuntimeManager.PlayOneShot(_destructionSound, this.transform.position);
+            }
         }
     }
 }

--- a/Assets/Scripts/Explosions.cs
+++ b/Assets/Scripts/Explosions.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using UnityEngine;
 using Bolt;
+using Cinemachine;
+using DG.Tweening;
 using Ludiq;
 
 public class Explosions : MonoBehaviour {

--- a/Assets/Scripts/GameLogic.cs
+++ b/Assets/Scripts/GameLogic.cs
@@ -26,8 +26,7 @@ public class GameLogic : MonoBehaviour {
     [BoxGroup("UI"), SerializeField] TextMeshProUGUI _gameOverHighScore;
     [BoxGroup("UI"), SerializeField] TextMeshProUGUI _startMenuHighScore;
 
-    [InfoBox("Make sure these match the exact names from the Input Manager.")]
-    [BoxGroup("Input"), SerializeField] string _pauseButton;
+    [BoxGroup("Input"), SerializeField, InputAxis] string _pauseButton;
 
     int _score = 0;
     int _highScore;
@@ -65,7 +64,7 @@ public class GameLogic : MonoBehaviour {
     }
 
     void Awake() {
-        DontDestroyOnLoad(this.gameObject);
+        //DontDestroyOnLoad(this.gameObject);
         _highScore = PlayerPrefs.GetInt("HighScore", 0);
     }
 

--- a/Assets/Scripts/NpcSpawner.cs
+++ b/Assets/Scripts/NpcSpawner.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+using NaughtyAttributes;
+
+public class NpcSpawner : MonoBehaviour {
+
+    const int _spawnQueueCount = 20;
+
+    [SerializeField, ReorderableList] List<GameObject> _npcPrefabs = new List<GameObject>();
+
+    Queue<GameObject> _npcQueue = new Queue<GameObject>();
+
+    public void SpawnNpc(int number) {
+        for (var i = 0; i < number; ++i) {
+            Vector3 spawnLocation = new Vector3();
+            for (var j = 0; j < 30; ++j) {
+                var vec2 = Vector2.zero + (Random.insideUnitCircle * 30f);
+                var randomPoint = new Vector3(vec2.x, 0f, vec2.y);
+                NavMeshHit hit;
+                if (NavMesh.SamplePosition(randomPoint, out hit, 1.0f, NavMesh.AllAreas)) {
+                    spawnLocation = hit.position;
+                    break;
+                }
+            }
+            var npc = _npcQueue.Dequeue();
+            npc.transform.position = spawnLocation;
+            npc.SetActive(true);
+        }
+    }
+
+    void Start() {
+        for (var i = 0; i < _spawnQueueCount; ++i) {
+            var index = Random.Range(0, _npcPrefabs.Count);
+            var npc = Instantiate(_npcPrefabs[index], Vector3.zero, Quaternion.identity, this.transform);
+            npc.SetActive(false);
+            _npcQueue.Enqueue(npc);
+        }
+
+        SpawnNpc(10);
+    }
+}

--- a/Assets/Scripts/NpcSpawner.cs.meta
+++ b/Assets/Scripts/NpcSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23291df07e1b3c84bb4f3b6378f79b7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -77,7 +77,7 @@ public class PlayerMovement : MonoBehaviour
     if (moveInput.magnitude > 0.1f)
     {
       var angle = Vector2.SignedAngle(Vector2.up, moveInput);
-      this.transform.rotation = Quaternion.Euler(0f, angle * 1, 0f);
+      this.transform.rotation = Quaternion.Euler(0f, angle * -1, 0f);
     }
 
     // Animator stuff


### PR DESCRIPTION
Set up basic NPC Spawner
- Updated camera controller to stop jittering.
- Updated player controller to correct rotation.

Update the main level with prefabs and spawner
- Added level bounds to keep the superheroes from flying out.
- Made sure only the inside buildings were destructible.
- Added explosion and window shattering sounds.
- Added Game Logic, NPCSpawner, FollowerManager, and Supers into the main level.